### PR TITLE
Add more ruby versions to the CI Matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,9 +12,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Ruby ${{ matrix.ruby }}
     strategy:
+      fail-fast: false
       matrix:
         ruby:
-          - '3.4.1'
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - '3.4.4'
+          - 'head'
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - '3.0'
-          - '3.1'
           - '3.2'
           - '3.3'
           - '3.4.4'


### PR DESCRIPTION
This pull request updates the Ruby testing matrix in the GitHub Actions workflow configuration to include additional Ruby versions and ensures the workflow does not fail fast when one job fails.

### Updates to GitHub Actions workflow:

* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R15-R23): Added `fail-fast: false` to the matrix strategy, preventing the workflow from stopping at the first job failure.
* [`.github/workflows/main.yml`](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R15-R23): Updated the Ruby matrix to test against versions `3.2`, `3.3`, `3.4.4`, and `head`, replacing the previous single version `3.4.1`.