### PR TITLE
Rename gem from SimpleHttp to MiniHttp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Ruby
+name: MiniHttp CI
 
 on:
   push:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,10 @@
 
 ## [0.1.0] - 2025-06-23
 
-- Initial release
+- Initial release of MiniHttp
+- Support for GET, POST, PUT, DELETE requests  
+- Automatic JSON parsing and serialization
+- SSL/HTTPS support with proper certificate verification
+- Configurable timeouts
+- Response helper methods for status checking
+- No external dependencies beyond Ruby standard library

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in simple_http.gemspec
+# Specify your gem's dependencies in mini_http.gemspec
 gemspec
 
 gem "irb"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    simple_http (0.1.0)
+    mini_http (0.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -90,10 +90,10 @@ PLATFORMS
 
 DEPENDENCIES
   irb
+  mini_http!
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)
-  simple_http!
   webmock (~> 3.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SimpleHttp
+# MiniHttp
 
-A simple, lightweight HTTP client library for Ruby that provides a clean interface for making HTTP requests with automatic JSON handling, SSL support, and customizable timeouts.
+A minimal, lightweight HTTP client library for Ruby that provides a clean interface for making HTTP requests withBug reports and pull requests are welcome on GitHub at https://github.com/felipecicolin/mini_http. This project is intended to be a safe, welcoming space for collaboration.automatic JSON handling, SSL support, and customizable timeouts.
 
 ## Features
 
@@ -16,7 +16,7 @@ A simple, lightweight HTTP client library for Ruby that provides a clean interfa
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'simple_http'
+gem 'mini_http'
 ```
 
 And then execute:
@@ -28,7 +28,7 @@ bundle install
 Or install it yourself as:
 
 ```bash
-gem install simple_http
+gem install mini_http
 ```
 
 ## Usage
@@ -36,7 +36,7 @@ gem install simple_http
 ### Basic GET request
 
 ```ruby
-response = SimpleHttp.get("https://api.example.com/users")
+response = MiniHttp.get("https://api.example.com/users")
 
 if response.success?
   users = response.json
@@ -49,7 +49,7 @@ end
 ### POST request with JSON body
 
 ```ruby
-response = SimpleHttp.post(
+response = MiniHttp.post(
   "https://api.example.com/users",
   body: { name: "John", email: "john@example.com" },
   headers: { "Authorization" => "Bearer token123" }
@@ -63,7 +63,7 @@ end
 ### PUT request
 
 ```ruby
-response = SimpleHttp.put(
+response = MiniHttp.put(
   "https://api.example.com/users/1",
   body: { name: "John Updated" },
   timeout: 60
@@ -73,7 +73,7 @@ response = SimpleHttp.put(
 ### DELETE request
 
 ```ruby
-response = SimpleHttp.delete(
+response = MiniHttp.delete(
   "https://api.example.com/users/1",
   headers: { "Authorization" => "Bearer token123" }
 )
@@ -82,7 +82,7 @@ response = SimpleHttp.delete(
 ### Response methods
 
 ```ruby
-response = SimpleHttp.get("https://api.example.com/data")
+response = MiniHttp.get("https://api.example.com/data")
 
 # Status checking
 response.success?       # true for 2xx status codes
@@ -105,7 +105,7 @@ All methods support these optional parameters:
 - `body`: Request body for POST/PUT (string or object that responds to `to_json`)
 
 ```ruby
-response = SimpleHttp.get(
+response = MiniHttp.get(
   "https://api.example.com/data",
   headers: {
     "User-Agent" => "MyApp/1.0",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MiniHttp
 
-A minimal, lightweight HTTP client library for Ruby that provides a clean interface for making HTTP requests withBug reports and pull requests are welcome on GitHub at https://github.com/felipecicolin/mini_http. This project is intended to be a safe, welcoming space for collaboration.automatic JSON handling, SSL support, and customizable timeouts.
+A minimal, lightweight HTTP client library for Ruby that provides a clean interface for making HTTP requests with automatic JSON handling, SSL support, and customizable timeouts.
 
 ## Features
 

--- a/lib/mini_http.rb
+++ b/lib/mini_http.rb
@@ -4,9 +4,9 @@ require "net/http"
 require "uri"
 require "json"
 require "openssl"
-require_relative "simple_http/version"
+require_relative "mini_http/version"
 
-class SimpleHttp
+class MiniHttp
   class Response
     SUCCESS_RANGE = (200..299).freeze
     CLIENT_ERROR_RANGE = (400..499).freeze

--- a/lib/mini_http/version.rb
+++ b/lib/mini_http/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class SimpleHttp
+class MiniHttp
   VERSION = "0.1.0"
 end

--- a/mini_http.gemspec
+++ b/mini_http.gemspec
@@ -1,25 +1,25 @@
 # frozen_string_literal: true
 
-require_relative "lib/simple_http/version"
+require_relative "lib/mini_http/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "simple_http"
-  spec.version = SimpleHttp::VERSION
+  spec.name = "mini_http"
+  spec.version = MiniHttp::VERSION
   spec.authors = ["Felipe Cicolin Rocha"]
   spec.email = ["felipecicolinrocha@gmail.com"]
 
-  spec.summary = "A simple HTTP client library for Ruby"
-  spec.description = "SimpleHttp provides a clean, easy-to-use interface for making HTTP requests " \
+  spec.summary = "A minimal HTTP client library for Ruby"
+  spec.description = "MiniHttp provides a clean, easy-to-use interface for making HTTP requests " \
                      "with automatic JSON handling, SSL support, and customizable timeouts."
-  spec.homepage = "https://github.com/felipecicolin/simple_http"
+  spec.homepage = "https://github.com/felipecicolin/mini_http"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 2.7.0"
 
   # spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/felipecicolin/simple_http"
-  spec.metadata["changelog_uri"] = "https://github.com/felipecicolin/simple_http/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/felipecicolin/mini_http"
+  spec.metadata["changelog_uri"] = "https://github.com/felipecicolin/mini_http/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.

--- a/spec/mini_http_spec.rb
+++ b/spec/mini_http_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe MiniHttp do
         .to_return(status: 200, body: "OK")
 
       response = MiniHttp.get("https://example.com/api",
-                                headers: { "Authorization" => "Bearer token123", "User-Agent" => "MyApp/1.0" })
+                              headers: { "Authorization" => "Bearer token123", "User-Agent" => "MyApp/1.0" })
 
       expect(response.success?).to be true
     end
@@ -105,8 +105,8 @@ RSpec.describe MiniHttp do
         .to_return(status: 201, body: "Created")
 
       response = MiniHttp.post("https://example.com/api",
-                                 body: { data: "test" },
-                                 headers: { "Content-Type" => "application/custom", "Authorization" => "Bearer token" })
+                               body: { data: "test" },
+                               headers: { "Content-Type" => "application/custom", "Authorization" => "Bearer token" })
 
       expect(response.success?).to be true
     end
@@ -154,7 +154,7 @@ RSpec.describe MiniHttp do
         .to_return(status: 204, body: "")
 
       response = MiniHttp.delete("https://example.com/api/1",
-                                   headers: { "Authorization" => "Bearer token123" })
+                                 headers: { "Authorization" => "Bearer token123" })
 
       expect(response.success?).to be true
     end

--- a/spec/mini_http_spec.rb
+++ b/spec/mini_http_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe MiniHttp do
         .with(headers: { "Authorization" => "Bearer token123", "User-Agent" => "MyApp/1.0" })
         .to_return(status: 200, body: "OK")
 
-      response = SimpleHttp.get("https://example.com/api",
+      response = MiniHttp.get("https://example.com/api",
                                 headers: { "Authorization" => "Bearer token123", "User-Agent" => "MyApp/1.0" })
 
       expect(response.success?).to be true
@@ -43,7 +43,7 @@ RSpec.describe MiniHttp do
       stub_request(:get, "https://example.com/api")
         .to_return(status: 200, body: "OK")
 
-      response = SimpleHttp.get("https://example.com/api", timeout: 60)
+      response = MiniHttp.get("https://example.com/api", timeout: 60)
 
       expect(response.success?).to be true
     end
@@ -52,7 +52,7 @@ RSpec.describe MiniHttp do
       stub_request(:get, "http://example.com/api")
         .to_return(status: 200, body: "OK")
 
-      response = SimpleHttp.get("http://example.com/api")
+      response = MiniHttp.get("http://example.com/api")
 
       expect(response.success?).to be true
     end
@@ -82,7 +82,7 @@ RSpec.describe MiniHttp do
         )
         .to_return(status: 201, body: "Created")
 
-      response = SimpleHttp.post("https://example.com/api", body: "raw string data")
+      response = MiniHttp.post("https://example.com/api", body: "raw string data")
 
       expect(response.success?).to be true
     end
@@ -91,7 +91,7 @@ RSpec.describe MiniHttp do
       stub_request(:post, "https://example.com/api")
         .to_return(status: 201, body: "Created")
 
-      response = SimpleHttp.post("https://example.com/api")
+      response = MiniHttp.post("https://example.com/api")
 
       expect(response.success?).to be true
     end
@@ -104,7 +104,7 @@ RSpec.describe MiniHttp do
         )
         .to_return(status: 201, body: "Created")
 
-      response = SimpleHttp.post("https://example.com/api",
+      response = MiniHttp.post("https://example.com/api",
                                  body: { data: "test" },
                                  headers: { "Content-Type" => "application/custom", "Authorization" => "Bearer token" })
 
@@ -131,7 +131,7 @@ RSpec.describe MiniHttp do
         )
         .to_return(status: 200, body: "Updated")
 
-      response = SimpleHttp.put("https://example.com/api/1", body: "updated data")
+      response = MiniHttp.put("https://example.com/api/1", body: "updated data")
 
       expect(response.success?).to be true
     end
@@ -153,7 +153,7 @@ RSpec.describe MiniHttp do
         .with(headers: { "Authorization" => "Bearer token123" })
         .to_return(status: 204, body: "")
 
-      response = SimpleHttp.delete("https://example.com/api/1",
+      response = MiniHttp.delete("https://example.com/api/1",
                                    headers: { "Authorization" => "Bearer token123" })
 
       expect(response.success?).to be true
@@ -163,7 +163,7 @@ RSpec.describe MiniHttp do
   describe "error handling" do
     it "raises ArgumentError for unsupported HTTP method" do
       expect do
-        SimpleHttp.send(:make_request, :patch, "https://example.com")
+        MiniHttp.send(:make_request, :patch, "https://example.com")
       end.to raise_error(ArgumentError, "Unsupported HTTP method: patch")
     end
 
@@ -172,13 +172,13 @@ RSpec.describe MiniHttp do
         .to_raise(Timeout::Error)
 
       expect do
-        SimpleHttp.get("https://example.com/api")
+        MiniHttp.get("https://example.com/api")
       end.to raise_error(Timeout::Error)
     end
 
     it "handles invalid URLs" do
       expect do
-        SimpleHttp.get("not-a-url")
+        MiniHttp.get("not-a-url")
       end.to raise_error(ArgumentError, "not an HTTP URI")
     end
   end
@@ -208,7 +208,7 @@ RSpec.describe MiniHttp do
       it "returns true for all 2xx codes" do
         (200..299).each do |code|
           allow(net_response).to receive(:code).and_return(code.to_s)
-          response = SimpleHttp::Response.new(net_response)
+          response = MiniHttp::Response.new(net_response)
           expect(response.success?).to be true
         end
       end
@@ -223,14 +223,14 @@ RSpec.describe MiniHttp do
 
       it "returns false for non-4xx status codes" do
         allow(net_response).to receive(:code).and_return("500")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.client_error?).to be false
       end
 
       it "returns true for all 4xx codes" do
         [400, 401, 403, 404, 422, 429, 499].each do |code|
           allow(net_response).to receive(:code).and_return(code.to_s)
-          response = SimpleHttp::Response.new(net_response)
+          response = MiniHttp::Response.new(net_response)
           expect(response.client_error?).to be true
         end
       end
@@ -245,14 +245,14 @@ RSpec.describe MiniHttp do
 
       it "returns false for non-5xx status codes" do
         allow(net_response).to receive(:code).and_return("404")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.server_error?).to be false
       end
 
       it "returns true for all 5xx codes" do
         [500, 501, 502, 503, 504, 599].each do |code|
           allow(net_response).to receive(:code).and_return(code.to_s)
-          response = SimpleHttp::Response.new(net_response)
+          response = MiniHttp::Response.new(net_response)
           expect(response.server_error?).to be true
         end
       end
@@ -277,19 +277,19 @@ RSpec.describe MiniHttp do
 
       it "handles empty response body" do
         allow(net_response).to receive(:body).and_return("")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.json).to be_nil
       end
 
       it "handles nil response body" do
         allow(net_response).to receive(:body).and_return(nil)
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.json).to be_nil
       end
 
       it "parses JSON arrays" do
         allow(net_response).to receive(:body).and_return('[{"id": 1}, {"id": 2}]')
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.json).to eq([{ "id" => 1 }, { "id" => 2 }])
       end
     end
@@ -297,7 +297,7 @@ RSpec.describe MiniHttp do
     describe "#code" do
       it "converts string status code to integer" do
         allow(net_response).to receive(:code).and_return("404")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.code).to eq(404)
         expect(response.code).to be_a(Integer)
       end

--- a/spec/mini_http_spec.rb
+++ b/spec/mini_http_spec.rb
@@ -2,7 +2,7 @@
 
 require "webmock/rspec"
 
-RSpec.describe SimpleHttp do
+RSpec.describe MiniHttp do
   before do
     WebMock.enable!
   end
@@ -12,7 +12,7 @@ RSpec.describe SimpleHttp do
   end
 
   it "has a version number" do
-    expect(SimpleHttp::VERSION).not_to be nil
+    expect(MiniHttp::VERSION).not_to be nil
   end
 
   describe ".get" do
@@ -20,9 +20,9 @@ RSpec.describe SimpleHttp do
       stub_request(:get, "https://example.com/api")
         .to_return(status: 200, body: '{"success": true}', headers: { "Content-Type" => "application/json" })
 
-      response = SimpleHttp.get("https://example.com/api")
+      response = MiniHttp.get("https://example.com/api")
 
-      expect(response).to be_a(SimpleHttp::Response)
+      expect(response).to be_a(MiniHttp::Response)
       expect(response.success?).to be true
       expect(response.code).to eq(200)
       expect(response.json).to eq({ "success" => true })
@@ -38,7 +38,7 @@ RSpec.describe SimpleHttp do
         )
         .to_return(status: 201, body: '{"id": 1, "name": "John"}')
 
-      response = SimpleHttp.post("https://example.com/api", body: { name: "John" })
+      response = MiniHttp.post("https://example.com/api", body: { name: "John" })
 
       expect(response.success?).to be true
       expect(response.code).to eq(201)
@@ -51,7 +51,7 @@ RSpec.describe SimpleHttp do
       stub_request(:put, "https://example.com/api/1")
         .to_return(status: 200, body: "OK")
 
-      response = SimpleHttp.put("https://example.com/api/1", body: { name: "Updated" })
+      response = MiniHttp.put("https://example.com/api/1", body: { name: "Updated" })
 
       expect(response.success?).to be true
       expect(response.code).to eq(200)
@@ -63,14 +63,14 @@ RSpec.describe SimpleHttp do
       stub_request(:delete, "https://example.com/api/1")
         .to_return(status: 204, body: "")
 
-      response = SimpleHttp.delete("https://example.com/api/1")
+      response = MiniHttp.delete("https://example.com/api/1")
 
       expect(response.success?).to be true
       expect(response.code).to eq(204)
     end
   end
 
-  describe SimpleHttp::Response do
+  describe MiniHttp::Response do
     let(:net_response) { double("Net::HTTPResponse") }
 
     before do
@@ -79,7 +79,7 @@ RSpec.describe SimpleHttp do
       allow(net_response).to receive(:to_hash).and_return({ "content-type" => ["application/json"] })
     end
 
-    let(:response) { SimpleHttp::Response.new(net_response) }
+    let(:response) { MiniHttp::Response.new(net_response) }
 
     describe "#success?" do
       it "returns true for 2xx status codes" do
@@ -88,7 +88,7 @@ RSpec.describe SimpleHttp do
 
       it "returns false for non-2xx status codes" do
         allow(net_response).to receive(:code).and_return("404")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.success?).to be false
       end
     end
@@ -96,7 +96,7 @@ RSpec.describe SimpleHttp do
     describe "#client_error?" do
       it "returns true for 4xx status codes" do
         allow(net_response).to receive(:code).and_return("404")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.client_error?).to be true
       end
     end
@@ -104,7 +104,7 @@ RSpec.describe SimpleHttp do
     describe "#server_error?" do
       it "returns true for 5xx status codes" do
         allow(net_response).to receive(:code).and_return("500")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.server_error?).to be true
       end
     end
@@ -116,7 +116,7 @@ RSpec.describe SimpleHttp do
 
       it "returns nil for invalid JSON" do
         allow(net_response).to receive(:body).and_return("invalid json")
-        response = SimpleHttp::Response.new(net_response)
+        response = MiniHttp::Response.new(net_response)
         expect(response.json).to be_nil
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require "simple_http"
+require "mini_http"
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
This pull request primarily renames the library and its components from `SimpleHttp` to `MiniHttp` while updating associated documentation, tests, and configuration files. It also expands the `CHANGELOG.md` to detail the features of the initial release.

### Library Renaming:
* Renamed all references to `SimpleHttp` to `MiniHttp` across the codebase, including class names, method calls, and file names. (`lib/mini_http.rb`, `lib/mini_http/version.rb`, `mini_http.gemspec`, `spec/mini_http_spec.rb`, `spec/spec_helper.rb`) [[1]](diffhunk://#diff-44556341c8e18822694bde815f0a3be82a6a0ba07b444c72e40acac4c2c5238aL7-R9) [[2]](diffhunk://#diff-cad27006f63e5df31526bdf39aaaccefcc61c4be188bd6e1c8d50e6e3e76f9feL3-R3) [[3]](diffhunk://#diff-7460aa2e9c2d7111ecd688934cdac03a44587e0c333fe3cb0471383ba8bc3ab8L3-R22) [[4]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L5-R5) [[5]](diffhunk://#diff-89eebfcbc0f14b6d989517837ca1e94fce4e2ce9a03233641cd936f2b8d2ed94L3-R3)

### Documentation Updates:
* Updated `README.md` to reflect the new library name (`MiniHttp`) and adjusted example code and installation instructions accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L1-R3) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L31-R39) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L52-R52) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L66-R66) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L76-R76) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L85-R85) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L108-R108)
* Enhanced `CHANGELOG.md` to include details about the initial release features such as support for HTTP methods, SSL, JSON handling, and configurable timeouts.

### Configuration Updates:
* Renamed the gemspec file and updated its metadata to align with the new library name (`mini_http.gemspec`).
* Updated the GitHub Actions workflow name to reflect the new library name. (`.github/workflows/main.yml`)

### Testing Updates:
* Updated all test cases in `spec/mini_http_spec.rb` to use `MiniHttp` instead of `SimpleHttp`. This includes renaming the test file itself and modifying assertions and method calls. [[1]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L5-R5) [[2]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L15-R25) [[3]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L41-R41) [[4]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L54-R54) [[5]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L66-R73) [[6]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L82-R82) [[7]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L91-R107) [[8]](diffhunk://#diff-5203f297557c5801f07ce64bc48fb502a204ca9fd66a91bfb10c67815de4cb53L119-R119)

These changes ensure consistency across the library, documentation, and tests while introducing no functional changes beyond the renaming.